### PR TITLE
Update Packer configuration for VirtualBox-ISO Ubuntu 16.04

### DIFF
--- a/VirtualBox-ISO/README.md
+++ b/VirtualBox-ISO/README.md
@@ -1,0 +1,29 @@
+# Packer Configuration for Ubuntu 16.04.6 Desktop with Apache Web Server
+
+This configuration file is used to create a VirtualBox virtual machine with Ubuntu 16.04.6 Desktop and install Apache web server on it using Packer.
+
+
+# Prerequisites
+
+    Packer
+    VirtualBox
+
+
+# Configuration
+
+This configuration file uses the 'virtualbox-iso' builder to create a VirtualBox virtual machine with Ubuntu 16.04.6 Desktop. The ISO file is downloaded from the URL specified in 'iso_url' and its SHA256 checksum is verified using 'iso_checksum'.
+
+The 'communicator' option is set to SSH which will be used to communicate with the virtual machine. The 'ssh_username' is set to 'ubuntu' which is the default username for Ubuntu virtual machines.
+
+The 'build' section specifies the source of the image and the provisioner to install Apache on the virtual machine. The source is set to 'source.virtualbox-iso.ubuntu' which refers to the 'virtualbox-iso' builder configuration.
+
+The 'provisioner' is set to 'shell' which executes a shell script on the virtual machine. The shell script installs Apache web server and enables its firewall rules.
+
+
+# Usage
+
+To build the virtual machine, run the following command in the directory containing this configuration file:
+
+packer build build.pkr.hcl 
+
+The resulting virtual machine will have Ubuntu 22.04.2 Desktop with Apache web server installed and ready to use.

--- a/VirtualBox-ISO/build.pkr.hcl
+++ b/VirtualBox-ISO/build.pkr.hcl
@@ -1,0 +1,41 @@
+# Define the source for building the VM
+source "virtualbox-iso" "ubuntu" {
+  
+  # Specify the checksum for the Ubuntu ISO file
+  iso_checksum         = "eecb9c8160cdb08adf0c2f17daa1d403f5a55f14a856a5973f32f267eb9db039"   
+  # Specify the URL of the Ubuntu ISO file
+  iso_url              = "http://releases.ubuntu.com/xenial/ubuntu-16.04.6-desktop-i386.iso"  
+  communicator         = "ssh"  # Specify the communication method to be used with the VM  
+  # Specify the username and password to be used for SSH login
+  ssh_username         = "admin"
+  ssh_password         = "PassWord"    
+  ssh_wait_timeout     = "1500s" # Specify the maximum time to wait for SSH connection  
+  cpus                 = 2
+  memory               = 2048
+  disk_size            = "20000"
+  hard_drive_interface = "sata" 
+  boot_wait            = "30s"
+  boot_command         = ["<tab> text ks=hd:/dev/fd0:ks.cfg ksdevice=eth0 net.ifnames=0 biosdevname=0<enter><wait>"]
+  floppy_files         = ["/home/tirdad/Packer/Packer_Tutorial/VirtualBox-ISO/http/preseed.cfg"]
+  guest_additions_mode = "attach"
+  http_directory       = "http"
+  guest_additions_path = "/home/tirdad/Downloads/VBoxGuestAdditions.iso"
+  shutdown_command     = "echo 'packer' | sudo -S shutdown -P now"  # Specify the command to be executed for shutting down the VM    
+  format               = "ova"  # Specify the format of the output file
+}
+
+# Build the VM using the source defined above
+build {
+  sources = ["source.virtualbox-iso.ubuntu"]
+  
+  # Install Apache web server on the VM using shell provisioner
+  provisioner "shell" {
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get install -y apache2",
+      "sudo ufw allow 'Apache'",
+      "sudo systemctl enable apache2",
+      "sudo systemctl start apache2"
+    ]
+  }
+}

--- a/VirtualBox-ISO/http/ks.cfg
+++ b/VirtualBox-ISO/http/ks.cfg
@@ -1,0 +1,74 @@
+# CentOS 7 Kickstart File - ks.cfg
+
+# For more information on kickstart syntax and commands, refer to the
+# CentOS Installation Guide:
+# https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html
+
+
+# Required settings
+lang en_US.UTF-8
+keyboard us
+timezone UTC
+rootpw vagrant
+
+#Auto Screenshots
+autostep --autoscreenshot
+
+# Optional settings
+install
+cdrom
+network --onboot=yes --device=eth0 --bootproto=dhcp --ipv6=auto
+firewall --disabled
+selinux --disabled
+bootloader --location=mbr --driveorder=sda
+
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+
+auth --enableshadow --passalgo=sha512
+firstboot --disabled
+reboot
+
+%packages --nobase --excludedocs
+# Prerequisites for installing VMware Tools or VirtualBox guest additions.
+# Put in kickstart to ensure first version installed is from install disk,
+# not latest from a mirror.
+# vagrant needs this to copy initial files via scp
+@core
+#openssh-clients
+#sudo
+%end
+
+
+%post --log=/root/ks-post.log
+
+
+# Install wget to download the vagrant key
+yum -y install wget
+
+
+# Add vagrant User to Sudoers
+useradd vagrant
+groupadd vagrant
+usermod -a -G vagrant vagrant
+echo "vagrant"|passwd --stdin vagrant
+echo "%vagrant		ALL=(ALL)	    NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^.*!visiblepw/#Defaults !visiblepw/" /etc/sudoers
+
+
+# Installing vagrant keys
+mkdir -m 0700 -p /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /home/vagrant/.ssh/authorized_keys
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+
+# Set hostname
+hostnamectl set-hostname zh-development
+
+# Customize the message of the day
+echo 'Zephop VM - CentOS 7 x86_x64' >> /etc/motd
+
+%end

--- a/VirtualBox-ISO/http/preseed.cfg
+++ b/VirtualBox-ISO/http/preseed.cfg
@@ -1,0 +1,61 @@
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US
+
+# Keyboard selection.
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/xkb-keymap select us
+
+choose-mirror-bin mirror/http/proxy string
+
+### Clock and time zone setup
+d-i clock-setup/utc boolean true
+d-i time/zone string UTC
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+# This is fairly safe to set, it makes grub install automatically to the MBR
+# if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# This one makes grub-installer install to the MBR if it also finds some other
+# OS, which is less safe as it might not be able to boot that other OS.
+d-i grub-installer/with_other_os boolean true
+
+### Mirror settings
+# If you select ftp, the mirror/country string does not need to be set.
+d-i mirror/country string manual
+d-i mirror/http/directory string /ubuntu/
+d-i mirror/http/hostname string archive.ubuntu.com
+d-i mirror/http/proxy string
+
+### Partitioning
+d-i partman-auto/method string lvm
+
+# This makes partman automatically partition without confirmation.
+d-i partman-md/confirm boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+### Account setup
+d-i passwd/user-fullname string vagrant
+d-i passwd/user-uid string 1000
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i passwd/username string vagrant
+
+# The installer will warn about weak passwords. If you are sure you know
+# what you're doing and want to override it, uncomment this.
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+
+### Package selection
+tasksel tasksel/first standard
+d-i pkgsel/include string openssh-server build-essential
+d-i pkgsel/install-language-support boolean false
+
+# disable automatic package updates
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade


### PR DESCRIPTION
This pull request updates the build.pkr.hcl file to include the latest configuration settings for the VirtualBox-ISO builder. The changes include specifying the checksum for the Ubuntu ISO file, the URL of the ISO file, the communication method to be used with the VM, the SSH login credentials, the number of CPU cores and memory to be assigned to the VM, the size of the hard disk, the path of the kickstart file for the installation, the time to wait for boot to complete, the command to be executed during boot, the method to attach the Guest Additions ISO to the VM, the path to the directory containing HTTP files, and the path to the Guest Additions ISO file.

These updates ensure that the VM is created with the appropriate settings and configurations required for smooth operation.